### PR TITLE
Fixes autoloading in Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Build and scale ecommerce with Schema. Create a free account at https://schema.i
 ## Example
 
 ```php
-<?php require_once("/path/to/schema-php-client/lib/Schema.php");
+require_once("/path/to/schema-php-client/lib/Schema.php");
 
-$client = new Schema\Client('<client-id>', '<client-hey>');
+$client = new Schema\Client('<client-id>', '<client-key>');
 
 $products = $client->get('/categories/shoes/products', array(
 	'color' => 'blue'
@@ -15,6 +15,39 @@ $products = $client->get('/categories/shoes/products', array(
 
 print_r($products);
 ```
+
+or with [Composer](https://getcomposer.org/doc/05-repositories.md#vcs)
+
+__composer.json__
+```json
+"require": {
+	"schemaio/schema-php-client" : "dev-master"
+},
+ "repositories": [
+	{
+		"type" : "vcs",
+		"url"  : "git@github.com:schemaio/schema-php-client.git"
+	}
+]
+```
+
+Then run `composer update` to download and install the library
+
+```php
+require __DIR__ . '/vendor/autoload.php';
+
+$client = new Schema\Client('<client-id>', '<client-key>');
+
+$products = $client->get('/categories/shoes/products', array(
+	'color' => 'blue'
+));
+
+print_r($products);
+
+```
+
+
+
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"ext-json": "*"
 	},
 	"autoload": {
-		"classmap": ["lib/Schema/"]
+		"classmap": ["lib/"]
 	}
 
 }


### PR DESCRIPTION
I was getting the following error from Composer.

```
[RuntimeException]
  Could not scan for classes inside "~pathtoproject/vendor/schemaio/schema-php-client/lib/Schema/" which does not appear to be a file nor a folder
```

Just needed to update the classmap path within `composer.json`

Also adds a bit of information about installing with Composer and a usage example
